### PR TITLE
Added support for all lifecycle events on iOS and Android

### DIFF
--- a/android/src/main/java/com/ajinasokan/flutter_fgbg/FlutterFGBGPlugin.java
+++ b/android/src/main/java/com/ajinasokan/flutter_fgbg/FlutterFGBGPlugin.java
@@ -55,19 +55,48 @@ public class FlutterFGBGPlugin implements FlutterPlugin, ActivityAware, Lifecycl
     ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
   }
 
-  @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
-  void onAppBackgrounded() {
-    if (lifecycleSink != null) {
-      lifecycleSink.success("background");
-    }
+  @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
+  void onAppCreated() {
+      if (lifecycleSink != null) {
+      lifecycleSink.success("ON_CREATE");
+      }
   }
 
   @OnLifecycleEvent(Lifecycle.Event.ON_START)
-  void onAppForegrounded() {
+  void onAppStarted() {
     if (lifecycleSink != null) {
-      lifecycleSink.success("foreground");
+      lifecycleSink.success("ON_START");
     }
   }
+
+  @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
+  void onAppResumed() {
+    if (lifecycleSink != null) {
+      lifecycleSink.success("ON_RESUME");
+    }
+  }
+
+  @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+  void onAppPaused() {
+    if (lifecycleSink != null) {
+      lifecycleSink.success("ON_PAUSE");
+    }
+  }
+
+  @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+  void onAppStopped() {
+    if (lifecycleSink != null) {
+      lifecycleSink.success("ON_STOP");
+    }
+  }
+
+  @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+  void onAppDestroy() {
+    if (lifecycleSink != null) {
+      lifecycleSink.success("ON_DESTROY");
+    }
+  }
+  
 
   @Override
   public void onDetachedFromActivityForConfigChanges() {}

--- a/ios/Classes/SwiftFlutterFgbgPlugin.swift
+++ b/ios/Classes/SwiftFlutterFgbgPlugin.swift
@@ -14,14 +14,32 @@ public class SwiftFlutterFGBGPlugin: NSObject, FlutterPlugin, FlutterStreamHandl
 
     let notificationCenter = NotificationCenter.default
     notificationCenter.addObserver(instance,
-                                   selector: #selector(didEnterBackground),
-                                   name: UIApplication.didEnterBackgroundNotification,
+                                   selector: #selector(didBecomeActive),
+                                   name: UIApplication.didBecomeActiveNotification,
                                    object: nil)
     
     notificationCenter.addObserver(instance,
-                                   selector: #selector(willEnterForeground),
-                                   name: UIApplication.willEnterForegroundNotification,
+                                   selector: #selector(didEnterBackground),
+                                   name: UIApplication.didEnterBackgroundNotification,
                                    object: nil)
+
+     notificationCenter.addObserver(instance,
+                                    selector: #selector(willEnterForeground),
+                                    name: UIApplication.willEnterForegroundNotification,
+                                    object: nil)
+    
+    notificationCenter.addObserver(instance,
+                                   selector: #selector(willResignActive),
+                                   name: UIApplication.willResignActiveNotification,
+                                   object: nil)
+    
+
+    notificationCenter.addObserver(instance,
+                                    selector: #selector(willTerminate),
+                                    name: UIApplication.willTerminateNotification,
+                                    object: nil)
+
+
   }
     
     public func onListen(withArguments arguments: Any?,
@@ -35,11 +53,24 @@ public class SwiftFlutterFGBGPlugin: NSObject, FlutterPlugin, FlutterStreamHandl
         return nil
     }
     
+    @objc func didBecomeActive() {
+        self.eventSink?("didBecomeActive")
+    }
+
     @objc func didEnterBackground() {
-        self.eventSink?("background")
+        self.eventSink?("didEnterBackground")
     }
 
     @objc func willEnterForeground() {
-        self.eventSink?("foreground")
+        self.eventSink?("willEnterForeground")
     }
+
+    @objc func willResignActive() {
+        self.eventSink?("willResignActive")
+    }
+
+    @objc func willTerminate() {
+        self.eventSink?("willTerminate")
+    }
+
 }

--- a/lib/flutter_fgbg.dart
+++ b/lib/flutter_fgbg.dart
@@ -4,16 +4,37 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 enum FGBGType {
-  foreground,
-  background,
+  enteredForeground,
+  enteredBackground,
+
+  willEnterForeground,
+
+  willStart,
+  willTerminate,
+
+  willSwitchContext,
 }
+
+Map<String, FGBGType> messageToFGBGMapping = {
+  // iOS Mappings
+  "didBecomeActive": FGBGType.willStart,
+  "didEnterBackground": FGBGType.enteredBackground,
+  "willEnterForeground": FGBGType.willEnterForeground,
+  "willResignActive": FGBGType.willSwitchContext,
+  "willTerminate": FGBGType.willTerminate,
+
+  // Android Mappings
+  "ON_CREATE": FGBGType.willStart,
+  "ON_STOP": FGBGType.enteredBackground,
+  "ON_RESUME": FGBGType.willEnterForeground,
+  "ON_PAUSE": FGBGType.willSwitchContext,
+  "ON_DESTROY": FGBGType.willTerminate,
+};
 
 class FGBGEvents {
   static const _channel = EventChannel("com.ajinasokan.flutter_fgbg/events");
 
-  static Stream<FGBGType> get stream =>
-      _channel.receiveBroadcastStream().map((event) =>
-          event == "foreground" ? FGBGType.foreground : FGBGType.background);
+  static Stream<FGBGType> get stream => _channel.receiveBroadcastStream().map((event) => messageToFGBGMapping[event]);
 }
 
 class FGBGNotifier extends StatefulWidget {

--- a/lib/flutter_fgbg.dart
+++ b/lib/flutter_fgbg.dart
@@ -34,7 +34,7 @@ Map<String, FGBGType> messageToFGBGMapping = {
 class FGBGEvents {
   static const _channel = EventChannel("com.ajinasokan.flutter_fgbg/events");
 
-  static Stream<FGBGType> get stream => _channel.receiveBroadcastStream().map((event) => messageToFGBGMapping[event]);
+  static Stream<FGBGType> get stream => _channel.receiveBroadcastStream().map((event) => messageToFGBGMapping[event]!);
 }
 
 class FGBGNotifier extends StatefulWidget {


### PR DESCRIPTION
I've added support for all lifecycle events on iOS and Android and are sending up the exact lifecycle transition from each platform in case you want to allow granular control of events by platform.