### PR TITLE
Allow multiple listeners on events stream

### DIFF
--- a/lib/flutter_fgbg.dart
+++ b/lib/flutter_fgbg.dart
@@ -10,10 +10,12 @@ enum FGBGType {
 
 class FGBGEvents {
   static const _channel = EventChannel("com.ajinasokan.flutter_fgbg/events");
+  static Stream<FGBGType>? _stream;
 
-  static Stream<FGBGType> get stream =>
-      _channel.receiveBroadcastStream().map((event) =>
+  static Stream<FGBGType> get stream {
+      return _stream ??= _channel.receiveBroadcastStream().map((event) =>
           event == "foreground" ? FGBGType.foreground : FGBGType.background);
+  }
 }
 
 class FGBGNotifier extends StatefulWidget {


### PR DESCRIPTION
Calling `receiveBroadcastStream` on flutter event channel unsubscribes the last listener before it subscribes a new listener. This causes every invocation of `FGBGEvents.stream` to unsubscribe previous listeners. Also as a side effect one can not both subscribe to a stream and use the `FGBGNotifier`.
After this fix the stream will be created once (one listener) and can be safely subscribed multiple times.