### PR TITLE
updated such that pub.dev advertises all supported platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0
+
+* Attempt to update the list of supported platforms on pub.dev, since now all supported Flutter platforms are supported by the plugin.
+
 ## 0.4.0
 
 * Desktop and Web fallbacks to `AppLifecycleListener` API. Thanks to #17 by @csells.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ StreamSubscription<FGBGType> subscription;
 
 ...
 // in initState
-subscription = FGBGEvents.stream.listen((event) {
+subscription = FGBGEvents.instance.stream.listen((event) {
     print(event); // FGBGType.foreground or FGBGType.background
 });
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.5.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_fgbg
 description: Flutter plugin to detect when app(not Flutter container) goes to background or foreground
-version: 0.4.0
+version: 0.5.0
 homepage: https://github.com/ajinasokan/flutter_fgbg
 
 environment:
@@ -15,15 +15,17 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
+# declare support for all of the following platforms, even though some of them
+# don't require any special setup or native code to work
+platforms:
+  android:
+  ios:
+  linux:
+  macos:
+  web:
+  windows:
 
-# The following section is specific to Flutter.
 flutter:
-  # This section identifies this Flutter project as a plugin project.
-  # The 'pluginClass' and Android 'package' identifiers should not ordinarily
-  # be modified. They are used by the tooling to maintain consistency when
-  # adding or updating assets for this project.
   plugin:
     platforms:
       android:
@@ -31,34 +33,3 @@ flutter:
         pluginClass: FlutterFGBGPlugin
       ios:
         pluginClass: FlutterFGBGPlugin
-
-  # To add assets to your plugin package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your plugin package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages


### PR DESCRIPTION
Updated according to [the Dart pubspec page](https://dart.dev/tools/pub/pubspec#platforms) to advertise support for all 6 platforms and not just Android and iOS. According to [the pana package](https://pub.dev/packages/pana), this update works to do just that:

```markdown
## ✓ Platform support (20 / 20)
### [*] 20/20 points: Supports 6 of 6 possible platforms (**iOS**, **Android**, **Web**, **Windows**, **macOS**, **Linux**)

* ✓ Android
* ✓ iOS
* ✓ Windows
* ✓ Linux
* ✓ macOS
* ✓ Web
```