### PR TITLE
Add support for widget tests

### DIFF
--- a/lib/flutter_fgbg.dart
+++ b/lib/flutter_fgbg.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -66,6 +65,11 @@ class FGBGEvents {
     } finally {
       _ignoreEvent = false;
     }
+  }
+
+  // Method to reset the singleton instance, useful for testing purposes.
+  static void reset() {
+    _instance = null;
   }
 }
 

--- a/lib/flutter_fgbg.dart
+++ b/lib/flutter_fgbg.dart
@@ -5,10 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
-enum FGBGType {
-  foreground,
-  background,
-}
+enum FGBGType { foreground, background }
 
 class FGBGEvents {
   FGBGEvents._() {}
@@ -23,11 +20,10 @@ class FGBGEvents {
     if (_controller == null) {
       _controller = StreamController<FGBGType>.broadcast();
 
-      if (!kIsWeb && (Platform.isAndroid || Platform.isIOS)) {
+      if (!kIsWeb && (defaultTargetPlatform == TargetPlatform.android || defaultTargetPlatform == TargetPlatform.iOS)) {
         _eventChannel
             .receiveBroadcastStream()
-            .map((e) =>
-                e == "foreground" ? FGBGType.foreground : FGBGType.background)
+            .map((e) => e == "foreground" ? FGBGType.foreground : FGBGType.background)
             .listen(_sendEvent);
       } else {
         // not disposing this. class is singleton, so only one instance
@@ -77,10 +73,7 @@ class FGBGNotifier extends StatefulWidget {
   final Widget child;
   final ValueChanged<FGBGType> onEvent;
 
-  FGBGNotifier({
-    required this.child,
-    required this.onEvent,
-  });
+  FGBGNotifier({required this.child, required this.onEvent});
 
   @override
   _FGBGNotifierState createState() => _FGBGNotifierState();


### PR DESCRIPTION
This PR aims to add support for writing tests using this package. Following is the summary of changes:

  1. Replace the usage of `Platform.isAndroid` and `Platform.isIOS` with `defaultTargetPlatform` because the `Platform.xxx` always return false in test environment and there is no way to mock it.

  2. Add a reset method to clear the instance/subscriptions between tests.